### PR TITLE
Follow REST for API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./public/index.js",
   "scripts": {
     "start": "webpack-dev-server .",
-    "dev": "NODE_ENV=development concurrently \" webpack-dev-server --progress --color \" \"nodemon ./server/server.js\"",
+    "dev": "NODE_ENV=development concurrently \" webpack-dev-server --progress --color \" \"nodemon --inspect ./server/server.js\"",
     "build": "webpack .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "front": "NODE_ENV=development webpack-dev-server --open",

--- a/server/actorController.js
+++ b/server/actorController.js
@@ -41,13 +41,14 @@ const actorController = {
 
   getActorCharacters: (req, res, next) => {
     // TODO: add query property to change what table we are checking
-    const { firstName, lastName, option } = req.query;
+    const { firstName, lastName, option } = req.params;
     let characterdb;
     if (option === 'test') {
       characterdb = 'test_characters';
     } else {
       characterdb = 'characters';
     }
+    // TODO use actorID to refer to actors rather than by concatenating firstName and lastName
     const values = [firstName, lastName];
     const text = `SELECT c.name as characterName
     FROM actors

--- a/server/scriptController.js
+++ b/server/scriptController.js
@@ -4,15 +4,14 @@ const db = require('./models/actorModels');
 const scriptController = {
   getPlay: (req, res, next) => {
     // TODO change reference to testplay or twelfthNightplay
-    const { title } = req.query;
-
+    const { title } = req.params;
     res.locals.fullPlay = playData[title].fullPlay;
     return next();
   },
 
   getCharacterData: (req, res, next) => {
     // TODO change reference to testplay or twelfthNightplay
-    const { title } = req.query;
+    const { title } = req.params;
     res.locals.characterData = playData[title].characterObjs;
     return next();
   },

--- a/server/server.js
+++ b/server/server.js
@@ -17,12 +17,12 @@ app.use(express.json());
 app.use(express.static(path.resolve(__dirname, '../public')));
 
 // returns the script as a nested array
-app.get('/script', scriptController.getPlay, (req, res) => {
+app.get('/script/:title', scriptController.getPlay, (req, res) => {
   return res.status(200).json(res.locals.fullPlay);
 });
 
 // return the character objects
-app.get('/characterData', scriptController.getCharacterData, (req, res) => {
+app.get('/characterData/:title', scriptController.getCharacterData, (req, res) => {
   return res.status(200).json(res.locals.characterData);
 });
 
@@ -32,7 +32,7 @@ app.get('/getActors', actorController.getActors, (req, res) => {
 });
 
 app.get(
-  '/currentCharacters',
+  '/currentCharacters/:firstName/:lastName/:option',
   actorController.getActorCharacters,
   (req, res) => {
     return res.status(200).json(res.locals.currentCharactersList);

--- a/src/components/actorScriptButton.jsx
+++ b/src/components/actorScriptButton.jsx
@@ -12,16 +12,12 @@ const ActorScriptButton = ({
   // on change, change the value of current actor
   const onClickChange = (e) => {
     const value = e.target.value.split(' ');
-    setCurrentActor([value[0], value[1]]);
-
-    // create url with current actor parameter name
-    let url = new URL('http://localhost:3000/currentCharacters');
-    url.searchParams.append('firstName', value[0]);
-    url.searchParams.append('lastName', value[1]);
-    url.searchParams.append('option', scriptOption);
+    const firstName = value[0];
+    const lastName = value[1];
+    setCurrentActor([firstName, lastName]);
 
     // fetch request to get the current characters for the current actor
-    fetch(url.href)
+    fetch(`/currentCharacters/${firstName}/${lastName}/${scriptOption}`)
       .then((response) => response.json())
       .then((characters) => {
         const charArr = characters.map((character) => character.charactername);

--- a/src/components/characterList.jsx
+++ b/src/components/characterList.jsx
@@ -4,13 +4,10 @@ import Character from './character';
 const CharacterList = ({ scriptOption }) => {
   const [characters, setCharacters] = useState([]);
   const fetchedCharacters = [];
-  let url = new URL('http://localhost:3000/characterData');
-  url.searchParams.append('title', scriptOption);
 
   useEffect(() => {
     // fetch request to get the character data
-
-    fetch(url.href)
+    fetch('/characterData/' + scriptOption)
       .then((response) => response.json())
       .then((characterObjs) => {
         for (let name in characterObjs) {

--- a/src/components/script.jsx
+++ b/src/components/script.jsx
@@ -11,11 +11,8 @@ const Script = ({ actors, scriptOption }) => {
   // fetch script from the backend
   let fullScript = [];
 
-  let url = new URL('http://localhost:3000/script');
-  url.searchParams.append('title', scriptOption);
-
   useEffect(() => {
-    fetch(url.href)
+    fetch('/script/' + scriptOption)
       .then((response) => response.json())
       .then((fetchedScript) => {
         for (let i = 0; i < fetchedScript.length; i++) {


### PR DESCRIPTION
This PR changes API calls to pass parameters via url paths.    

Currently, the code passes parameters for API calls via url query params.
Resource identifiers (such as the script title) tend to fit better in url paths rather than as query parameters since query parameters are set up to be optional.


For example, consider what happens when visiting the correct url and the url without the title parameter:
|url|returns|
|---|---|
|/script?title=twelfthnight|twelfthnight script contents|
|/script| 500 status code since the handler for the /script endpoint is missing the title parameter|

vs putting the parameters in the url path:

|url|returns|
|---|---|
|/script/twelfthnight|twelfthnight script contents|
|/script| 404 status code since express doesn't even run the handler for /script/:title|

 

This has the additional benefit of not having to hardcode the server's url with `new URL('http://localhost:3000/script');`. We rely on the browser to send our request to whatever place we initially loaded the page from. 

For example, if we loaded the page from `localhost:3000`, a fetch request to `/script` will be sent to `localhost:3000/script`.   If we loaded the page from somewhere else (like production), it would have a different url.    
If production was deployed to `playreading.cheman.org`, then the current code would still try to send api requests to `localhost:3000/script` rather than the correct url of `playreading.cheman.org/script`.

________
See https://stackoverflow.com/questions/4024271/rest-api-best-practices-where-to-put-parameters for more info.